### PR TITLE
create doorman's home dir

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,7 +8,6 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: centos-7.0
   - name: centos-7.2
 
 verifier:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,9 +9,12 @@ provisioner:
 
 platforms:
   - name: centos-7.0
+  - name: centos-7.2
+
+verifier:
+  name: inspec
 
 suites:
   - name: default
     run_list:
       - recipe[doorman::default]
-    attributes:

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,6 +9,7 @@ package "git"
 user "doorman" do
   action :create
   shell "/bin/false"
+  manage_home true
 end
 
 git "/home/doorman/doorman" do

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,0 +1,10 @@
+describe user('doorman') do
+  it { should exist }
+  its('home') { should eq '/home/doorman' }
+  its('shell') { should eq '/bin/false' }
+end
+
+describe directory('/home/doorman') do
+  it { should be_owned_by 'doorman' }
+  its('type') { should eq :directory }
+end


### PR DESCRIPTION
since the default recipe assumes doorman's home dir is being created, this pr explicitly states that in the user resource. also, adds a few specs to verify and changes the TK suite to build on 7.2.  everything needed to run the tests (`kitchen test/verify`) is provided by chefdk.